### PR TITLE
feat: edit todo items in-place

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,26 @@
       word-break: break-word;
     }
 
+    /* Edit input */
+    .edit-input {
+      flex: 1;
+      font-size: 1rem;
+      font-family: inherit;
+      padding: 0.25rem 0.375rem;
+      border: 1px solid #4a90d9;
+      border-radius: 4px;
+      background: #f9f9f9;
+      color: #1a1a1a;
+      outline: none;
+      box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.15);
+    }
+
+    .edit-input:focus {
+      outline: none;
+      border-color: #4a90d9;
+      box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.25);
+    }
+
     /* Status: done */
     #todo-list li.status-done {
       opacity: 0.6;

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,8 @@ import {
   loadTodos,
   saveTodos,
   setStatus,
-  toggleBlocker
+  toggleBlocker,
+  updateTodoText
 } from './todo/model.js';
 
 // OWNERSHIP: main.js is the orchestrator.
@@ -40,6 +41,7 @@ if (typeof document !== 'undefined') {
     let dagExpanded = !isMobileViewport() && hasDependencies(todos);
     let dagToggleTouched = false;
     let flashTimeoutId = null;
+    let editingId = null;
 
     const dagView = createDagView({
       container: dagContainer,
@@ -86,6 +88,31 @@ if (typeof document !== 'undefined') {
       if (shouldFlash) {
         flashTaskRow(taskElement);
       }
+    }
+
+    function enterEditMode(id) {
+      editingId = id;
+      render();
+      const input = document.querySelector(`li[data-id="${id}"] .edit-input`);
+      if (input) {
+        input.focus();
+        input.select();
+      }
+    }
+
+    function saveEdit(newText) {
+      if (!editingId) return;
+      const trimmed = newText.trim();
+      if (!trimmed) return; // Reject empty: keep input focused
+      todos = updateTodoText(todos, editingId, newText);
+      saveTodos(todos);
+      editingId = null;
+      render();
+    }
+
+    function cancelEdit() {
+      editingId = null;
+      render();
     }
 
     function syncDagState() {
@@ -182,9 +209,35 @@ if (typeof document !== 'undefined') {
           render();
         });
 
-        li.append(handle, select, text, deleteBtn);
+        if (editingId === todo.id) {
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.className = 'edit-input';
+          input.value = todo.text;
+          input.setAttribute('aria-label', `Edit "${todo.text}"`);
+          input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              saveEdit(input.value);
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancelEdit();
+            }
+          });
+          input.addEventListener('blur', () => {
+            if (editingId === todo.id) {
+              saveEdit(input.value);
+            }
+          });
+          li.append(handle, select, input, deleteBtn);
+        } else {
+          text.addEventListener('dblclick', () => {
+            enterEditMode(todo.id);
+          });
+          li.append(handle, select, text, deleteBtn);
+        }
 
-        if (todo.status === 'blocked') {
+        if (todo.status === 'blocked' && editingId !== todo.id) {
           if (Array.isArray(todo.blockedBy) && todo.blockedBy.length > 0) {
             const blockerNames = todo.blockedBy
               .map(bid => {

--- a/src/todo/model.js
+++ b/src/todo/model.js
@@ -124,3 +124,13 @@ export function clearFinished(todos) {
 export function hasDependencies(todos) {
   return todos.some(todo => Array.isArray(todo.blockedBy) && todo.blockedBy.length > 0);
 }
+
+export function updateTodoText(todos, id, newText) {
+  const trimmed = newText.trim();
+  if (!trimmed) return todos;
+
+  return todos.map(todo => {
+    if (todo.id !== id) return todo;
+    return { ...todo, text: trimmed };
+  });
+}

--- a/src/todo/model.test.js
+++ b/src/todo/model.test.js
@@ -9,7 +9,8 @@ import {
   toggleBlocker,
   cleanupBlockedBy,
   deleteTodo,
-  clearFinished
+  clearFinished,
+  updateTodoText
 } from './model.js';
 
 describe('generateId', () => {
@@ -520,5 +521,106 @@ describe('clearFinished', () => {
     const result = clearFinished(todos);
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('4');
+  });
+});
+
+describe('updateTodoText', () => {
+  it('updates the text of an existing todo', () => {
+    const todos = [
+      { id: '1', text: 'Buy milk', status: 'active' },
+      { id: '2', text: 'Walk dog', status: 'done' }
+    ];
+    const result = updateTodoText(todos, '1', 'Buy oat milk');
+    expect(result[0].text).toBe('Buy oat milk');
+  });
+
+  it('returns a NEW array (immutability)', () => {
+    const todos = [{ id: '1', text: 'task', status: 'active' }];
+    const result = updateTodoText(todos, '1', 'updated task');
+    expect(result).not.toBe(todos);
+  });
+
+  it('does not mutate the original todo object', () => {
+    const original = { id: '1', text: 'task', status: 'active' };
+    const todos = [original];
+    updateTodoText(todos, '1', 'updated task');
+    expect(original.text).toBe('task');
+  });
+
+  it('persists updated text through saveTodos/loadTodos round-trip', () => {
+    const mockStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    const todos = [{ id: '1', text: 'old text', status: 'active' }];
+    const updated = updateTodoText(todos, '1', 'new text');
+
+    saveTodos(updated, mockStorage, 'testKey');
+    mockStorage.getItem.mockReturnValue(mockStorage.setItem.mock.calls[0][1]);
+    const loaded = loadTodos(mockStorage, 'testKey');
+
+    expect(loaded[0].text).toBe('new text');
+  });
+
+  it('returns todos unchanged for empty text', () => {
+    const todos = [{ id: '1', text: 'task', status: 'active' }];
+    const result = updateTodoText(todos, '1', '');
+    expect(result).toEqual(todos);
+  });
+
+  it('returns todos unchanged for whitespace-only text', () => {
+    const todos = [{ id: '1', text: 'task', status: 'active' }];
+    const result = updateTodoText(todos, '1', '   \n\t  ');
+    expect(result).toEqual(todos);
+  });
+
+  it('is a no-op when the todo id does not exist', () => {
+    const todos = [{ id: '1', text: 'task', status: 'active' }];
+    const result = updateTodoText(todos, 'nonexistent', 'new text');
+    expect(result).toEqual(todos);
+  });
+
+  it('does not change the todo status', () => {
+    const todos = [{ id: '1', text: 'task', status: 'done' }];
+    const result = updateTodoText(todos, '1', 'updated task');
+    expect(result[0].status).toBe('done');
+  });
+
+  it('does not change blockedBy on a blocked todo', () => {
+    const todos = [{ id: '1', text: 'task', status: 'blocked', blockedBy: ['2', '3'] }];
+    const result = updateTodoText(todos, '1', 'updated task');
+    expect(result[0].status).toBe('blocked');
+    expect(result[0].blockedBy).toEqual(['2', '3']);
+  });
+
+  it('preserves position of the updated todo in the array', () => {
+    const todos = [
+      { id: '1', text: 'first', status: 'active' },
+      { id: '2', text: 'second', status: 'active' },
+      { id: '3', text: 'third', status: 'active' }
+    ];
+    const result = updateTodoText(todos, '2', 'edited second');
+    expect(result[0].id).toBe('1');
+    expect(result[1].id).toBe('2');
+    expect(result[1].text).toBe('edited second');
+    expect(result[2].id).toBe('3');
+  });
+
+  it('leaves other todos unchanged', () => {
+    const todos = [
+      { id: '1', text: 'task1', status: 'active' },
+      { id: '2', text: 'task2', status: 'done' }
+    ];
+    const result = updateTodoText(todos, '1', 'updated');
+    expect(result[1]).toEqual(todos[1]);
+  });
+
+  it('trims leading and trailing whitespace from new text', () => {
+    const todos = [{ id: '1', text: 'task', status: 'active' }];
+    const result = updateTodoText(todos, '1', '  trimmed text  ');
+    expect(result[0].text).toBe('trimmed text');
+  });
+
+  it('preserves the todo id after update', () => {
+    const todos = [{ id: '1', text: 'task', status: 'active' }];
+    const result = updateTodoText(todos, '1', 'new text');
+    expect(result[0].id).toBe('1');
   });
 });


### PR DESCRIPTION
Double-click any todo text to edit it inline. Enter saves, Escape cancels, blur saves. Empty text is rejected. All 101 tests pass.