### PR TITLE
feat: Actionable Now filter toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A lightweight, zero-friction browser-based todo app built with vanilla JavaScrip
 - **📝 Quick task capture** — Type and press Enter to add a new todo instantly
 - **🎯 Four-state tracking** — Mark tasks as Active, Done, Cancelled, or Blocked
 - **🔗 Dependency tracking** — Flag blocked tasks and specify what's holding them up
+- **✅ Actionable Now filter** — Focus on only the tasks you can work on right now
 - **📊 Dependency graph** — Visualize task dependencies with an interactive DAG
 - **🎚️ Drag-to-reorder** — Grab any task and drag it to your preferred position
 - **📋 Clear clutter** — Remove all completed and cancelled tasks with one click
@@ -71,6 +72,7 @@ npm test:watch
 - **Change status:** Click the status dropdown (Active, Done, Cancelled, Blocked)
 - **Block tasks:** Mark as Blocked and check which tasks are blocking it
 - **Reorder:** Drag the ⋮ handle to move tasks up or down
+- **Focus:** Toggle "Actionable" to hide done, cancelled, and blocked tasks
 - **Visualize:** Click "Dependencies" to see task blocking relationships in a graph
 - **Clean up:** Click "Clear finished" to remove Done and Cancelled tasks
 

--- a/index.html
+++ b/index.html
@@ -44,6 +44,57 @@
       margin-bottom: 1.5rem;
     }
 
+    .list-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      margin-bottom: 0.875rem;
+      flex-wrap: wrap;
+    }
+
+    .list-toolbar-copy {
+      flex: 1;
+      min-width: 180px;
+    }
+
+    #actionable-filter-toggle {
+      padding: 0.45rem 0.8rem;
+      font-size: 0.875rem;
+      font-family: inherit;
+      font-weight: 600;
+      color: #4f5d75;
+      background: #fff;
+      border: 1px solid #d7dce4;
+      border-radius: 999px;
+      cursor: pointer;
+      min-height: 40px;
+      transition: background 0.15s, border-color 0.15s, color 0.15s, box-shadow 0.15s;
+    }
+
+    #actionable-filter-toggle:hover {
+      background: #f6f8fb;
+      border-color: #bcc7d6;
+      color: #243447;
+    }
+
+    #actionable-filter-toggle.is-active {
+      background: #eef6ff;
+      border-color: #4a90d9;
+      color: #2563a6;
+      box-shadow: inset 0 0 0 1px rgba(74, 144, 217, 0.12);
+    }
+
+    #actionable-filter-toggle:focus-visible {
+      outline: 2px solid #4a90d9;
+      outline-offset: 2px;
+    }
+
+    #actionable-summary {
+      color: #667085;
+      font-size: 0.875rem;
+    }
+
     .input-row label {
       position: absolute;
       width: 1px;
@@ -627,6 +678,18 @@
     }
 
     @media (max-width: 479px) {
+      .list-toolbar {
+        align-items: stretch;
+      }
+
+      .list-toolbar-copy {
+        min-width: 100%;
+      }
+
+      #actionable-filter-toggle {
+        width: 100%;
+      }
+
       #dependency-graph-section {
         width: calc(100vw - 1rem);
       }
@@ -666,6 +729,13 @@
         >
         <button type="submit" id="add-btn">Add</button>
       </form>
+
+      <div class="list-toolbar">
+        <button type="button" id="actionable-filter-toggle" aria-pressed="false">Actionable</button>
+        <div class="list-toolbar-copy">
+          <p id="actionable-summary" role="status">0 of 0 tasks are actionable</p>
+        </div>
+      </div>
 
       <p id="empty-state" role="status">No todos yet. Add one above!</p>
 

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import {
   cleanupBlockedBy,
   clearFinished,
   deleteTodo,
+  getActionableCount,
+  getActionableTodos,
   hasDependencies,
   loadTodos,
   saveTodos,
@@ -18,8 +20,26 @@ import {
 // - Owns: #dag-toggle, #dag-summary, #dag-empty-state, #dependency-graph-section
 // - dag/view.js owns only SVG rendering inside #dependency-graph container
 
+const ACTIONABLE_FILTER_STORAGE_KEY = 'bumbledo_filter_actionable';
+
 function isMobileViewport() {
   return window.matchMedia('(max-width: 479px)').matches;
+}
+
+function loadActionableFilterPreference() {
+  try {
+    return localStorage.getItem(ACTIONABLE_FILTER_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function saveActionableFilterPreference(isActive) {
+  try {
+    localStorage.setItem(ACTIONABLE_FILTER_STORAGE_KEY, String(isActive));
+  } catch {
+    // Ignore storage write failures so the UI stays usable.
+  }
 }
 
 // DOM initialization - runs on load
@@ -28,6 +48,8 @@ if (typeof document !== 'undefined') {
     const todoList = document.getElementById('todo-list');
     const todoInput = document.getElementById('todo-input');
     const addForm = document.getElementById('add-form');
+    const actionableFilterToggle = document.getElementById('actionable-filter-toggle');
+    const actionableSummary = document.getElementById('actionable-summary');
     const emptyState = document.getElementById('empty-state');
     const clearFinishedBtn = document.getElementById('clear-finished-btn');
     const dagSection = document.getElementById('dependency-graph-section');
@@ -38,6 +60,7 @@ if (typeof document !== 'undefined') {
 
     let todos = loadTodos();
     let selectedTaskId = null;
+    let filterActive = loadActionableFilterPreference();
     let dagExpanded = !isMobileViewport() && hasDependencies(todos);
     let dagToggleTouched = false;
     let flashTimeoutId = null;
@@ -142,18 +165,69 @@ if (typeof document !== 'undefined') {
       }
     }
 
+    function reorderVisibleTodos(draggedId, targetId, insertAfter) {
+      if (filterActive) {
+        const visibleTodos = getActionableTodos(todos);
+        const draggedIndex = visibleTodos.findIndex(todo => todo.id === draggedId);
+        if (draggedIndex === -1) return todos;
+
+        const reorderedVisible = [...visibleTodos];
+        const [movedTodo] = reorderedVisible.splice(draggedIndex, 1);
+        let targetIndex = reorderedVisible.findIndex(todo => todo.id === targetId);
+
+        if (!movedTodo || targetIndex === -1) return todos;
+        if (insertAfter) targetIndex += 1;
+
+        reorderedVisible.splice(targetIndex, 0, movedTodo);
+
+        let visibleIndex = 0;
+        return todos.map(todo => {
+          if (todo.status !== 'active') {
+            return todo;
+          }
+
+          const replacement = reorderedVisible[visibleIndex];
+          visibleIndex += 1;
+          return replacement ?? todo;
+        });
+      }
+
+      const reorderedTodos = [...todos];
+      const fromIndex = reorderedTodos.findIndex(todo => todo.id === draggedId);
+      if (fromIndex === -1) return todos;
+
+      const [movedTodo] = reorderedTodos.splice(fromIndex, 1);
+      let toIndex = reorderedTodos.findIndex(todo => todo.id === targetId);
+
+      if (!movedTodo || toIndex === -1) return todos;
+      if (insertAfter) toIndex += 1;
+
+      reorderedTodos.splice(toIndex, 0, movedTodo);
+      return reorderedTodos;
+    }
+
     function render() {
       if (!todos.some(todo => todo.id === selectedTaskId)) {
         selectedTaskId = null;
       }
 
+      const { actionable, total } = getActionableCount(todos);
+      const visibleTodos = filterActive ? getActionableTodos(todos) : todos;
+      const showActionableEmptyState = filterActive && total > 0 && actionable === 0;
+
       todoList.innerHTML = '';
 
       const hasFinished = todos.some(t => t.status === 'done' || t.status === 'cancelled');
       clearFinishedBtn.disabled = !hasFinished;
-      emptyState.hidden = todos.length > 0;
+      actionableFilterToggle.classList.toggle('is-active', filterActive);
+      actionableFilterToggle.setAttribute('aria-pressed', String(filterActive));
+      actionableSummary.textContent = `${actionable} of ${total} tasks are actionable`;
+      emptyState.hidden = total > 0 ? !showActionableEmptyState : false;
+      emptyState.textContent = total === 0
+        ? 'No todos yet. Add one above!'
+        : 'Nothing actionable right now. All your tasks are either done or waiting on something.';
 
-      todos.forEach(todo => {
+      visibleTodos.forEach(todo => {
         const li = document.createElement('li');
         li.draggable = true;
         li.dataset.id = todo.id;
@@ -327,6 +401,12 @@ if (typeof document !== 'undefined') {
       todoInput.focus();
     });
 
+    actionableFilterToggle.addEventListener('click', () => {
+      filterActive = !filterActive;
+      saveActionableFilterPreference(filterActive);
+      render();
+    });
+
     clearFinishedBtn.addEventListener('click', () => {
       todos = clearFinished(todos);
       if (!todos.some(todo => todo.id === selectedTaskId)) {
@@ -396,19 +476,13 @@ if (typeof document !== 'undefined') {
       const targetLi = e.target.closest('li[data-id]');
       if (!targetLi || !draggedId) return;
 
-      const fromIndex = todos.findIndex(t => t.id === draggedId);
       const targetId = targetLi.dataset.id;
       if (draggedId === targetId) return;
 
       const rect = targetLi.getBoundingClientRect();
       const insertAfter = e.clientY >= rect.top + rect.height / 2;
 
-      const [moved] = todos.splice(fromIndex, 1);
-
-      let toIndex = todos.findIndex(t => t.id === targetId);
-      if (insertAfter) toIndex += 1;
-
-      todos.splice(toIndex, 0, moved);
+      todos = reorderVisibleTodos(draggedId, targetId, insertAfter);
       saveTodos(todos);
       render();
     });

--- a/src/todo/model.js
+++ b/src/todo/model.js
@@ -125,6 +125,17 @@ export function hasDependencies(todos) {
   return todos.some(todo => Array.isArray(todo.blockedBy) && todo.blockedBy.length > 0);
 }
 
+export function getActionableCount(todos) {
+  return {
+    actionable: todos.filter(todo => todo.status === 'active').length,
+    total: todos.length
+  };
+}
+
+export function getActionableTodos(todos) {
+  return todos.filter(todo => todo.status === 'active');
+}
+
 export function updateTodoText(todos, id, newText) {
   const trimmed = newText.trim();
   if (!trimmed) return todos;

--- a/src/todo/model.test.js
+++ b/src/todo/model.test.js
@@ -10,6 +10,8 @@ import {
   cleanupBlockedBy,
   deleteTodo,
   clearFinished,
+  getActionableCount,
+  getActionableTodos,
   updateTodoText
 } from './model.js';
 
@@ -521,6 +523,121 @@ describe('clearFinished', () => {
     const result = clearFinished(todos);
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('4');
+  });
+});
+
+describe('getActionableTodos', () => {
+  it('returns only active tasks', () => {
+    const todos = [
+      { id: '1', text: 'active task', status: 'active' },
+      { id: '2', text: 'done task', status: 'done' },
+      { id: '3', text: 'cancelled task', status: 'cancelled' },
+      { id: '4', text: 'blocked task', status: 'blocked', blockedBy: ['1'] }
+    ];
+    const result = getActionableTodos(todos);
+    expect(result).toEqual([{ id: '1', text: 'active task', status: 'active' }]);
+  });
+
+  it('returns empty array when no active tasks exist', () => {
+    const todos = [
+      { id: '1', text: 'done task', status: 'done' },
+      { id: '2', text: 'cancelled task', status: 'cancelled' },
+      { id: '3', text: 'blocked task', status: 'blocked', blockedBy: ['1'] }
+    ];
+    const result = getActionableTodos(todos);
+    expect(result).toEqual([]);
+  });
+
+  it('returns all tasks when all are active', () => {
+    const todos = [
+      { id: '1', text: 'task1', status: 'active' },
+      { id: '2', text: 'task2', status: 'active' },
+      { id: '3', text: 'task3', status: 'active' }
+    ];
+    const result = getActionableTodos(todos);
+    expect(result).toEqual(todos);
+  });
+
+  it('returns the two active tasks from a mixed-status list', () => {
+    const todos = [
+      { id: '1', text: 'active one', status: 'active' },
+      { id: '2', text: 'done task', status: 'done' },
+      { id: '3', text: 'active two', status: 'active' },
+      { id: '4', text: 'cancelled task', status: 'cancelled' },
+      { id: '5', text: 'blocked task', status: 'blocked', blockedBy: ['1'] }
+    ];
+    const result = getActionableTodos(todos);
+    expect(result).toEqual([
+      { id: '1', text: 'active one', status: 'active' },
+      { id: '3', text: 'active two', status: 'active' }
+    ]);
+  });
+
+  it('returns empty array for empty input', () => {
+    const result = getActionableTodos([]);
+    expect(result).toEqual([]);
+  });
+
+  it('includes a newly added active task in the results', () => {
+    const todos = [{ id: '1', text: 'existing done', status: 'done' }];
+    const updated = addTodo(todos, 'new actionable task');
+    const result = getActionableTodos(updated);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      text: 'new actionable task',
+      status: 'active'
+    });
+  });
+
+  it('includes a task after it auto-unblocks back to active', () => {
+    const todos = [
+      { id: '1', text: 'blocker', status: 'active' },
+      { id: '2', text: 'blocked task', status: 'blocked', blockedBy: ['1'] }
+    ];
+    const updated = cleanupBlockedBy(todos, '1');
+    const result = getActionableTodos(updated);
+    expect(result).toEqual([
+      { id: '1', text: 'blocker', status: 'active' },
+      { id: '2', text: 'blocked task', status: 'active' }
+    ]);
+  });
+});
+
+describe('getActionableCount', () => {
+  it('returns correct actionable and total counts for a mixed list', () => {
+    const todos = [
+      { id: '1', text: 'task1', status: 'active' },
+      { id: '2', text: 'task2', status: 'done' },
+      { id: '3', text: 'task3', status: 'active' },
+      { id: '4', text: 'task4', status: 'cancelled' },
+      { id: '5', text: 'task5', status: 'active' }
+    ];
+    const result = getActionableCount(todos);
+    expect(result).toEqual({ actionable: 3, total: 5 });
+  });
+
+  it('returns matching actionable and total counts when all tasks are active', () => {
+    const todos = [
+      { id: '1', text: 'task1', status: 'active' },
+      { id: '2', text: 'task2', status: 'active' }
+    ];
+    const result = getActionableCount(todos);
+    expect(result).toEqual({ actionable: 2, total: 2 });
+  });
+
+  it('returns zero actionable when no tasks are active', () => {
+    const todos = [
+      { id: '1', text: 'task1', status: 'done' },
+      { id: '2', text: 'task2', status: 'cancelled' },
+      { id: '3', text: 'task3', status: 'blocked', blockedBy: ['1'] }
+    ];
+    const result = getActionableCount(todos);
+    expect(result).toEqual({ actionable: 0, total: 3 });
+  });
+
+  it('returns zero counts for an empty list', () => {
+    const result = getActionableCount([]);
+    expect(result).toEqual({ actionable: 0, total: 0 });
   });
 });
 


### PR DESCRIPTION
## What

Implements **PRD-actionable-now.md** — the highest-priority feature identified by Tess.

### Changes
- **Filter toggle** near task list: shows only active (actionable) tasks
- **Live count summary**: "N of M tasks are actionable"
- **localStorage persistence**: filter preference remembered across sessions (`bumbledo_filter_actionable`)
- **Drag-and-drop in filtered mode**: reorders visible items while preserving full list positions
- **Actionable-specific empty state**: "Nothing actionable right now..." when all tasks are filtered out
- **11 new unit tests** for `getActionableTodos` / `getActionableCount` model functions

### Acceptance Criteria Coverage
All 14 acceptance criteria from PRD-actionable-now.md are addressed.

### Testing
- 112 tests pass (89 model + 23 DAG)
- `npm run build` succeeds clean

---
*Built by Rusty (implementation) and Linus (tests).*