### PR TITLE
feat: Burndown View — dual-line progress chart

### DIFF
--- a/.squad/agents/linus/history.md
+++ b/.squad/agents/linus/history.md
@@ -8,6 +8,23 @@
 
 ## Learnings
 
+### 2026-03-29: Burndown view data-layer contract tests
+
+**What I delivered:**
+- Added 14 model-layer unit tests in `src/todo/model.test.js` for the planned burndown helpers `takeBurndownSample()`, `shouldSampleToday()`, and `pruneBurndownData()`
+- Kept the tests at the pure-function level and called the pending helpers through the `model` namespace so the suite still loads cleanly during TDD
+- Added stable date fixtures with fake timers so day-based assertions stay deterministic across statuses, sampling checks, and 30-day pruning behavior
+
+**Coverage focus:**
+- Snapshot counting for mixed statuses, all-active, all-done, empty input, and date formatting
+- Daily sampling rules for empty history, existing same-day sample, yesterday-only data, and multi-entry history without today's sample
+- Retention logic for within-window data, selective pruning of >30-day entries, empty input, and the exact 30-day boundary
+
+**Execution outcome:**
+- Baseline before changes: full Vitest suite was green (`139` tests passing)
+- After adding the burndown contract tests: `14` expected red tests fail because the three burndown helpers are not yet implemented/exported from `src/todo/model.js`
+- This gives Rusty a precise TDD target for the burndown data layer without coupling coverage to storage or UI behavior
+
 ### 2026-03-29: clearFinished unblock-detection regression coverage
 
 **What I delivered:**

--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -142,3 +142,14 @@
 **Interaction rules to preserve:**
 - Unblock highlights live only in memory, expire after 3 seconds, and are cleared immediately by clicking the row or dismissing the alert.
 - The alert auto-hides after 5 seconds, announces task names for screen readers, and does not change persisted todo data.
+
+### 2026-03-29: Burndown View
+
+**What I implemented:**
+- Added burndown sampling helpers in `src/todo/model.js` for daily snapshots stored in `todos_burndown` with retention pruning and same-day duplicate protection.
+- Added a collapsible Progress section inside `index.html` with responsive summary, legend, empty state, SVG chart shell, and hover tooltip styling.
+- Wired `src/main.js` to sample once on load, render cumulative completed-vs-total lines, and keep the chart hidden until the user expands it.
+
+**Interaction rules to preserve:**
+- Burndown samples are taken only on first load of a local calendar day; chart data is historical and does not live-update with in-session edits.
+- The chart summary uses monotonic rendered series so completed/total lines never visually move backward, even if users later clear finished tasks from the live list.

--- a/index.html
+++ b/index.html
@@ -381,6 +381,174 @@
       font-size: 1rem;
     }
 
+    #burndown-section {
+      margin: 1rem 0 1.5rem;
+      padding: 1rem;
+      background: #fbfcfe;
+      border: 1px solid #e3e8ef;
+      border-radius: 12px;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+    }
+
+    .burndown-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .burndown-title-group h2 {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #111;
+    }
+
+    .burndown-helper {
+      margin-top: 0.125rem;
+      font-size: 0.875rem;
+      color: #667085;
+    }
+
+    #burndown-toggle {
+      padding: 0.5rem 0.85rem;
+      font-size: 0.875rem;
+      font-family: inherit;
+      font-weight: 600;
+      color: #4a90d9;
+      background: #fff;
+      border: 1px solid #cfe0f5;
+      border-radius: 999px;
+      cursor: pointer;
+      min-height: 40px;
+      white-space: nowrap;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+    }
+
+    #burndown-toggle:hover {
+      background: #f4f8fd;
+      border-color: #4a90d9;
+    }
+
+    #burndown-toggle:focus-visible {
+      outline: 2px solid #4a90d9;
+      outline-offset: 2px;
+    }
+
+    #burndown-collapsed-summary {
+      color: #4f5d75;
+      font-size: 0.9rem;
+      line-height: 1.45;
+    }
+
+    #burndown-panel[hidden] {
+      display: none;
+    }
+
+    .burndown-summary {
+      margin: 0.25rem 0 0.75rem;
+    }
+
+    #burndown-summary-headline {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: #111827;
+      line-height: 1.2;
+    }
+
+    #burndown-summary-detail {
+      margin-top: 0.2rem;
+      color: #667085;
+      font-size: 0.95rem;
+    }
+
+    .burndown-legend {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.75rem;
+      color: #667085;
+      font-size: 0.8125rem;
+    }
+
+    .burndown-legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .burndown-legend-swatch {
+      width: 0.9rem;
+      height: 0.9rem;
+      border-radius: 999px;
+      flex-shrink: 0;
+    }
+
+    .burndown-legend-swatch.is-completed {
+      background: #2f8f63;
+    }
+
+    .burndown-legend-swatch.is-total {
+      background: #4a90d9;
+    }
+
+    #burndown-empty-state {
+      min-height: 96px;
+      padding: 1rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #fff;
+      border: 1px dashed #d9dfe8;
+      border-radius: 10px;
+      color: #667085;
+      font-size: 0.9375rem;
+      text-align: center;
+    }
+
+    #burndown-empty-state[hidden] {
+      display: none;
+    }
+
+    #burndown-chart {
+      position: relative;
+      background: #fff;
+      border: 1px solid #e5eaf1;
+      border-radius: 10px;
+      padding: 0.25rem;
+      overflow: hidden;
+    }
+
+    #burndown-chart[hidden] {
+      display: none;
+    }
+
+    #burndown-chart-svg {
+      width: 100%;
+      height: 280px;
+      display: block;
+    }
+
+    .burndown-tooltip {
+      position: absolute;
+      z-index: 2;
+      min-width: 152px;
+      padding: 0.5rem 0.625rem;
+      background: rgba(17, 24, 39, 0.96);
+      color: #fff;
+      border-radius: 8px;
+      font-size: 0.8125rem;
+      line-height: 1.4;
+      pointer-events: none;
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.2);
+    }
+
+    .burndown-tooltip strong {
+      display: block;
+      margin-bottom: 0.2rem;
+      font-size: 0.875rem;
+    }
+
     /* Footer */
     footer {
       text-align: center;
@@ -920,6 +1088,32 @@
         width: 100%;
       }
 
+      #burndown-section {
+        padding: 0.875rem;
+      }
+
+      .burndown-header {
+        align-items: flex-start;
+      }
+
+      .burndown-helper {
+        display: none;
+      }
+
+      #burndown-summary-headline {
+        font-size: 1.125rem;
+      }
+
+      #burndown-summary-detail,
+      #burndown-collapsed-summary,
+      .burndown-legend {
+        font-size: 0.8125rem;
+      }
+
+      #burndown-chart-svg {
+        height: 220px;
+      }
+
       #dependency-graph-section {
         width: calc(100vw - 1rem);
       }
@@ -1004,6 +1198,43 @@
       <p id="empty-state" role="status">No todos yet. Add one above!</p>
 
       <ul id="todo-list" aria-label="Todo list" tabindex="-1"></ul>
+
+      <section id="burndown-section" aria-labelledby="burndown-title">
+        <div class="burndown-header">
+          <div class="burndown-title-group">
+            <h2 id="burndown-title">Burndown</h2>
+            <p class="burndown-helper">Completed versus total tasks over the last 30 days</p>
+          </div>
+          <button type="button" id="burndown-toggle" aria-expanded="false" aria-controls="burndown-panel">Progress</button>
+        </div>
+
+        <p id="burndown-collapsed-summary" role="status">0 done · 0 remaining · First sample today</p>
+
+        <div id="burndown-panel" hidden>
+          <div class="burndown-summary">
+            <p id="burndown-summary-headline">0 of 0 done (0%)</p>
+            <p id="burndown-summary-detail">0 remaining</p>
+          </div>
+
+          <div class="burndown-legend" aria-hidden="true">
+            <span class="burndown-legend-item">
+              <span class="burndown-legend-swatch is-completed"></span>
+              Completed
+            </span>
+            <span class="burndown-legend-item">
+              <span class="burndown-legend-swatch is-total"></span>
+              Total
+            </span>
+          </div>
+
+          <p id="burndown-empty-state" role="status" hidden>Not enough data yet. Come back in a few days!</p>
+
+          <div id="burndown-chart" hidden>
+            <svg id="burndown-chart-svg"></svg>
+            <div id="burndown-tooltip" class="burndown-tooltip" hidden></div>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer>

--- a/src/main.js
+++ b/src/main.js
@@ -9,9 +9,13 @@ import {
   getActionableCount,
   getActionableTodos,
   hasDependencies,
+  loadBurndownData,
   loadTodos,
   saveTodos,
+  saveBurndownData,
   setStatus,
+  shouldSampleToday,
+  takeBurndownSample,
   toggleBlocker,
   updateTodoText
 } from './todo/model.js';
@@ -22,6 +26,99 @@ import {
 // - dag/view.js owns only SVG rendering inside #dependency-graph container
 
 const ACTIONABLE_FILTER_STORAGE_KEY = 'bumbledo_filter_actionable';
+const BURNDOWN_STORAGE_KEY = 'todos_burndown';
+const BURNDOWN_TOTAL_COLOR = '#4a90d9';
+const BURNDOWN_COMPLETED_COLOR = '#2f8f63';
+const BURNDOWN_GAP_COLOR = 'rgba(74, 144, 217, 0.12)';
+
+function parseBurndownDate(dateKey) {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function formatBurndownDate(dateKey, options) {
+  return new Intl.DateTimeFormat(undefined, options).format(parseBurndownDate(dateKey));
+}
+
+function buildBurndownSeries(samples) {
+  let completedMax = 0;
+  let totalMax = 0;
+
+  return samples.map((sample) => {
+    const completed = sample.done + sample.cancelled;
+    completedMax = Math.max(completedMax, completed);
+    totalMax = Math.max(totalMax, sample.total, completedMax);
+
+    return {
+      ...sample,
+      completed: completedMax,
+      total: totalMax
+    };
+  });
+}
+
+function getBurndownSummary(series, todos = []) {
+  if (series.length === 0) {
+    const fallbackSample = takeBurndownSample(todos);
+    const completed = fallbackSample.done + fallbackSample.cancelled;
+    const remaining = Math.max(0, fallbackSample.total - completed);
+    const percent = fallbackSample.total === 0 ? 0 : Math.round((completed / fallbackSample.total) * 100);
+
+    return {
+      completed,
+      total: fallbackSample.total,
+      remaining,
+      percent,
+      deltaToday: 0,
+      hasDelta: false
+    };
+  }
+
+  const latest = series[series.length - 1];
+  const previous = series[series.length - 2] ?? null;
+  const remaining = Math.max(0, latest.total - latest.completed);
+  const percent = latest.total === 0 ? 0 : Math.round((latest.completed / latest.total) * 100);
+
+  return {
+    completed: latest.completed,
+    total: latest.total,
+    remaining,
+    percent,
+    deltaToday: previous ? latest.completed - previous.completed : latest.completed,
+    hasDelta: previous !== null
+  };
+}
+
+function buildBurndownCollapsedSummary(summary) {
+  const deltaText = summary.hasDelta
+    ? `${summary.deltaToday >= 0 ? '+' : ''}${summary.deltaToday} done today`
+    : 'First sample today';
+
+  return `${summary.completed} done · ${summary.remaining} remaining · ${deltaText}`;
+}
+
+function buildBurndownPath(points) {
+  return points.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`).join(' ');
+}
+
+function buildBurndownAreaPath(upperPoints, lowerPoints) {
+  if (upperPoints.length === 0 || lowerPoints.length === 0) {
+    return '';
+  }
+
+  const start = `M ${upperPoints[0].x} ${upperPoints[0].y}`;
+  const upperPath = upperPoints.slice(1).map(point => `L ${point.x} ${point.y}`).join(' ');
+  const lowerPath = [...lowerPoints].reverse().map(point => `L ${point.x} ${point.y}`).join(' ');
+  return `${start} ${upperPath} ${lowerPath} Z`;
+}
+
+function createSvgElement(tagName, attributes = {}) {
+  const element = document.createElementNS('http://www.w3.org/2000/svg', tagName);
+  Object.entries(attributes).forEach(([key, value]) => {
+    element.setAttribute(key, String(value));
+  });
+  return element;
+}
 
 function isMobileViewport() {
   return window.matchMedia('(max-width: 479px)').matches;
@@ -72,6 +169,15 @@ if (typeof document !== 'undefined') {
     const actionableFilterToggle = document.getElementById('actionable-filter-toggle');
     const actionableSummary = document.getElementById('actionable-summary');
     const emptyState = document.getElementById('empty-state');
+    const burndownToggle = document.getElementById('burndown-toggle');
+    const burndownCollapsedSummary = document.getElementById('burndown-collapsed-summary');
+    const burndownPanel = document.getElementById('burndown-panel');
+    const burndownSummaryHeadline = document.getElementById('burndown-summary-headline');
+    const burndownSummaryDetail = document.getElementById('burndown-summary-detail');
+    const burndownEmptyState = document.getElementById('burndown-empty-state');
+    const burndownChart = document.getElementById('burndown-chart');
+    const burndownChartSvg = document.getElementById('burndown-chart-svg');
+    const burndownTooltip = document.getElementById('burndown-tooltip');
     const clearFinishedBtn = document.getElementById('clear-finished-btn');
     const dagSection = document.getElementById('dependency-graph-section');
     const dagContainer = document.getElementById('dependency-graph');
@@ -84,8 +190,10 @@ if (typeof document !== 'undefined') {
     const focusInputShortcut = document.getElementById('focus-input-shortcut');
 
     let todos = loadTodos();
+    let burndownData = loadBurndownData();
     let selectedTaskId = null;
     let filterActive = loadActionableFilterPreference();
+    let burndownExpanded = false;
     let dagExpanded = !isMobileViewport() && hasDependencies(todos);
     let dagToggleTouched = false;
     let flashTimeoutId = null;
@@ -98,6 +206,10 @@ if (typeof document !== 'undefined') {
     const unblockedHighlightTimeoutIds = new Map();
 
     const prefersMacKeys = isMacPlatform();
+
+    if (shouldSampleToday(burndownData)) {
+      burndownData = saveBurndownData([...burndownData, takeBurndownSample(todos)], undefined, BURNDOWN_STORAGE_KEY);
+    }
 
     if (focusInputShortcut) {
       focusInputShortcut.innerHTML = prefersMacKeys
@@ -392,6 +504,209 @@ if (typeof document !== 'undefined') {
       }
     }
 
+    function hideBurndownTooltip() {
+      burndownTooltip.hidden = true;
+      burndownTooltip.textContent = '';
+      burndownTooltip.style.left = '';
+      burndownTooltip.style.top = '';
+    }
+
+    function showBurndownTooltip(point, viewBoxWidth, viewBoxHeight) {
+      burndownTooltip.innerHTML = `
+        <strong>${formatBurndownDate(point.date, { month: 'short', day: 'numeric', year: 'numeric' })}</strong>
+        <div>Completed: ${point.completed}</div>
+        <div>Total: ${point.total}</div>
+      `;
+      burndownTooltip.hidden = false;
+
+      const chartRect = burndownChart.getBoundingClientRect();
+      const x = (point.x / viewBoxWidth) * chartRect.width;
+      const y = (Math.min(point.completedY, point.totalY) / viewBoxHeight) * chartRect.height;
+
+      const tooltipWidth = burndownTooltip.offsetWidth;
+      const tooltipHeight = burndownTooltip.offsetHeight;
+      const left = Math.max(8, Math.min(chartRect.width - tooltipWidth - 8, x - (tooltipWidth / 2)));
+      const top = Math.max(8, y - tooltipHeight - 12);
+
+      burndownTooltip.style.left = `${left}px`;
+      burndownTooltip.style.top = `${top}px`;
+    }
+
+    function renderBurndownChart(series) {
+      const mobile = isMobileViewport();
+      const width = 640;
+      const height = mobile ? 220 : 280;
+      const margin = mobile
+        ? { top: 20, right: 12, bottom: 34, left: 34 }
+        : { top: 24, right: 20, bottom: 40, left: 42 };
+      const chartWidth = width - margin.left - margin.right;
+      const chartHeight = height - margin.top - margin.bottom;
+      const maxY = Math.max(1, ...series.map(point => point.total));
+      const tickCount = maxY >= 6 ? 4 : 3;
+      const yTicks = [...new Set(
+        Array.from({ length: tickCount }, (_, index) => Math.round((maxY / (tickCount - 1)) * index))
+      )];
+      const xLabelEvery = Math.max(1, Math.ceil(series.length / (mobile ? 3 : 6)));
+      const shouldShowXAxisLabel = (index) => (
+        index === 0
+        || index === series.length - 1
+        || index % xLabelEvery === 0
+      );
+      const getX = (index) => (
+        series.length === 1
+          ? margin.left + (chartWidth / 2)
+          : margin.left + ((chartWidth * index) / (series.length - 1))
+      );
+      const getY = (value) => margin.top + chartHeight - ((value / maxY) * chartHeight);
+
+      const totalPoints = series.map((point, index) => ({
+        ...point,
+        x: getX(index),
+        y: getY(point.total)
+      }));
+      const completedPoints = series.map((point, index) => ({
+        ...point,
+        x: getX(index),
+        y: getY(point.completed)
+      }));
+
+      burndownChartSvg.innerHTML = '';
+      burndownChartSvg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+      burndownChartSvg.setAttribute('role', 'img');
+      burndownChartSvg.setAttribute('aria-label', 'Burndown chart showing completed work versus total work over time');
+
+      yTicks.forEach((tick) => {
+        const y = getY(tick);
+        burndownChartSvg.appendChild(createSvgElement('line', {
+          x1: margin.left,
+          y1: y,
+          x2: width - margin.right,
+          y2: y,
+          stroke: '#e3e8ef',
+          'stroke-width': 1
+        }));
+
+        const tickLabel = createSvgElement('text', {
+          x: margin.left - 8,
+          y: y + 4,
+          'text-anchor': 'end',
+          fill: '#7c8798',
+          'font-size': mobile ? 10 : 11
+        });
+        tickLabel.textContent = String(tick);
+        burndownChartSvg.appendChild(tickLabel);
+      });
+
+      const gapArea = createSvgElement('path', {
+        d: buildBurndownAreaPath(totalPoints, completedPoints),
+        fill: BURNDOWN_GAP_COLOR,
+        stroke: 'none'
+      });
+      burndownChartSvg.appendChild(gapArea);
+
+      const totalLine = createSvgElement('path', {
+        d: buildBurndownPath(totalPoints),
+        fill: 'none',
+        stroke: BURNDOWN_TOTAL_COLOR,
+        'stroke-width': 2.5,
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round'
+      });
+      burndownChartSvg.appendChild(totalLine);
+
+      const completedLine = createSvgElement('path', {
+        d: buildBurndownPath(completedPoints),
+        fill: 'none',
+        stroke: BURNDOWN_COMPLETED_COLOR,
+        'stroke-width': 2.5,
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round'
+      });
+      burndownChartSvg.appendChild(completedLine);
+
+      totalPoints.forEach((point, index) => {
+        const completedPoint = completedPoints[index];
+
+        burndownChartSvg.appendChild(createSvgElement('circle', {
+          cx: point.x,
+          cy: point.y,
+          r: 3.5,
+          fill: '#fff',
+          stroke: BURNDOWN_TOTAL_COLOR,
+          'stroke-width': 2
+        }));
+
+        burndownChartSvg.appendChild(createSvgElement('circle', {
+          cx: completedPoint.x,
+          cy: completedPoint.y,
+          r: 3.5,
+          fill: '#fff',
+          stroke: BURNDOWN_COMPLETED_COLOR,
+          'stroke-width': 2
+        }));
+
+        if (shouldShowXAxisLabel(index)) {
+          const xAxisLabel = createSvgElement('text', {
+            x: point.x,
+            y: height - 10,
+            'text-anchor': 'middle',
+            fill: '#7c8798',
+            'font-size': mobile ? 10 : 11
+          });
+          xAxisLabel.textContent = formatBurndownDate(point.date, mobile
+            ? { month: 'numeric', day: 'numeric' }
+            : { month: 'short', day: 'numeric' });
+          burndownChartSvg.appendChild(xAxisLabel);
+        }
+
+        const hitTarget = createSvgElement('rect', {
+          x: point.x - Math.max(18, chartWidth / Math.max(8, series.length * 2)),
+          y: margin.top,
+          width: Math.max(36, chartWidth / Math.max(4, series.length)),
+          height: chartHeight,
+          fill: 'transparent',
+          tabindex: 0,
+          'aria-label': `${formatBurndownDate(point.date, { month: 'short', day: 'numeric', year: 'numeric' })}: ${completedPoint.completed} completed, ${point.total} total`
+        });
+
+        const tooltipPoint = {
+          ...point,
+          completed: completedPoint.completed,
+          completedY: completedPoint.y,
+          totalY: point.y
+        };
+
+        hitTarget.addEventListener('mouseenter', () => showBurndownTooltip(tooltipPoint, width, height));
+        hitTarget.addEventListener('focus', () => showBurndownTooltip(tooltipPoint, width, height));
+        hitTarget.addEventListener('mouseleave', hideBurndownTooltip);
+        hitTarget.addEventListener('blur', hideBurndownTooltip);
+        burndownChartSvg.appendChild(hitTarget);
+      });
+    }
+
+    function syncBurndownState() {
+      const series = buildBurndownSeries(burndownData);
+      const summary = getBurndownSummary(series, todos);
+
+      burndownToggle.setAttribute('aria-expanded', String(burndownExpanded));
+      burndownCollapsedSummary.textContent = buildBurndownCollapsedSummary(summary);
+      burndownCollapsedSummary.hidden = burndownExpanded;
+      burndownPanel.hidden = !burndownExpanded;
+      burndownSummaryHeadline.textContent = `${summary.completed} of ${summary.total} done (${summary.percent}%)`;
+      burndownSummaryDetail.textContent = `${summary.remaining} remaining`;
+
+      const hasEnoughData = series.length >= 3;
+      burndownEmptyState.hidden = hasEnoughData;
+      burndownChart.hidden = !hasEnoughData;
+
+      if (burndownExpanded && hasEnoughData) {
+        renderBurndownChart(series);
+      } else {
+        burndownChartSvg.innerHTML = '';
+        hideBurndownTooltip();
+      }
+    }
+
     function syncDagState() {
       const { hasDependencies: dependencyState, stats } = buildDependencyGraph(todos);
 
@@ -662,6 +977,7 @@ if (typeof document !== 'undefined') {
       });
 
       syncTaskRowSelection();
+      syncBurndownState();
       syncDagState();
     }
 
@@ -695,6 +1011,11 @@ if (typeof document !== 'undefined') {
       render();
     });
 
+    burndownToggle.addEventListener('click', () => {
+      burndownExpanded = !burndownExpanded;
+      syncBurndownState();
+    });
+
     dagToggle.addEventListener('click', () => {
       if (!hasDependencies(todos)) {
         return;
@@ -705,11 +1026,14 @@ if (typeof document !== 'undefined') {
     });
 
     window.addEventListener('resize', () => {
+      syncBurndownState();
       if (!dagToggleTouched) {
         dagExpanded = hasDependencies(todos) && !isMobileViewport();
       }
       syncDagState();
     });
+
+    burndownChartSvg.addEventListener('mouseleave', hideBurndownTooltip);
 
     shortcutsHelpBtn.addEventListener('click', () => {
       if (helpModalOpen) {

--- a/src/todo/model.js
+++ b/src/todo/model.js
@@ -8,6 +8,89 @@ const defaultStorage = {
   setItem: (key, value) => localStorage.setItem(key, value)
 };
 
+const BURNDOWN_STORAGE_KEY = 'todos_burndown';
+const BURNDOWN_RETENTION_DAYS = 30;
+
+function padDatePart(value) {
+  return String(value).padStart(2, '0');
+}
+
+function getLocalDateKey(date = new Date()) {
+  return `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}`;
+}
+
+function parseDateKey(dateKey) {
+  if (typeof dateKey !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) {
+    return null;
+  }
+
+  const [year, month, day] = dateKey.split('-').map(Number);
+  const parsed = new Date(year, month - 1, day);
+
+  if (
+    parsed.getFullYear() !== year
+    || parsed.getMonth() !== month - 1
+    || parsed.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function getBurndownCutoffDate(now = new Date()) {
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate() - BURNDOWN_RETENTION_DAYS);
+}
+
+function normalizeBurndownEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const parsedDate = parseDateKey(entry.date);
+  if (!parsedDate) {
+    return null;
+  }
+
+  const done = Number.isFinite(entry.done) ? Math.max(0, Math.floor(entry.done)) : 0;
+  const cancelled = Number.isFinite(entry.cancelled) ? Math.max(0, Math.floor(entry.cancelled)) : 0;
+  const active = Number.isFinite(entry.active) ? Math.max(0, Math.floor(entry.active)) : 0;
+  const fallbackTotal = done + cancelled + active;
+  const total = Number.isFinite(entry.total) ? Math.max(0, Math.floor(entry.total)) : fallbackTotal;
+
+  return {
+    date: getLocalDateKey(parsedDate),
+    done,
+    cancelled,
+    active,
+    total
+  };
+}
+
+export function pruneBurndownData(data, now = new Date()) {
+  const cutoff = getBurndownCutoffDate(now);
+  const seenDates = new Set();
+  const normalized = data.map(normalizeBurndownEntry);
+  const pruned = [];
+
+  for (let index = normalized.length - 1; index >= 0; index -= 1) {
+    const entry = normalized[index];
+    if (!entry || seenDates.has(entry.date)) {
+      continue;
+    }
+
+    const parsedDate = parseDateKey(entry.date);
+    if (!parsedDate || parsedDate < cutoff) {
+      continue;
+    }
+
+    seenDates.add(entry.date);
+    pruned.unshift(entry);
+  }
+
+  return pruned;
+}
+
 // Pure logic functions - exported for testing
 
 export function generateId() {
@@ -49,6 +132,41 @@ export function saveTodos(todosToSave, storage = defaultStorage, storageKey = 't
     return obj;
   });
   storage.setItem(storageKey, JSON.stringify(clean));
+}
+
+export function takeBurndownSample(todos, now = new Date()) {
+  const done = todos.filter(todo => todo.status === 'done').length;
+  const cancelled = todos.filter(todo => todo.status === 'cancelled').length;
+  const active = todos.filter(todo => todo.status === 'active' || todo.status === 'blocked').length;
+
+  return {
+    date: getLocalDateKey(now),
+    done,
+    cancelled,
+    active,
+    total: done + cancelled + active
+  };
+}
+
+export function loadBurndownData(storage = defaultStorage, storageKey = BURNDOWN_STORAGE_KEY) {
+  try {
+    const data = storage.getItem(storageKey);
+    const parsed = data ? JSON.parse(data) : [];
+    return pruneBurndownData(Array.isArray(parsed) ? parsed : []);
+  } catch {
+    return [];
+  }
+}
+
+export function saveBurndownData(data, storage = defaultStorage, storageKey = BURNDOWN_STORAGE_KEY, now = new Date()) {
+  const clean = pruneBurndownData(Array.isArray(data) ? data : [], now);
+  storage.setItem(storageKey, JSON.stringify(clean));
+  return clean;
+}
+
+export function shouldSampleToday(data, now = new Date()) {
+  const today = getLocalDateKey(now);
+  return !pruneBurndownData(Array.isArray(data) ? data : [], now).some(entry => entry.date === today);
 }
 
 export function addTodo(todos, text) {

--- a/src/todo/model.test.js
+++ b/src/todo/model.test.js
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as model from './model.js';
 import {
   generateId,
   migrateTodos,
   loadTodos,
+  loadBurndownData,
   saveTodos,
+  saveBurndownData,
   addTodo,
   setStatus,
   toggleBlocker,
@@ -172,6 +174,75 @@ describe('saveTodos', () => {
     
     const saved = JSON.parse(mockStorage.setItem.mock.calls[0][1]);
     expect(saved[0]).toEqual({ id: '1', text: 'task', status: 'done' });
+  });
+});
+
+describe('burndown helpers', () => {
+  let mockStorage;
+
+  beforeEach(() => {
+    mockStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn()
+    };
+  });
+
+  describe('loadBurndownData', () => {
+    it('loads burndown samples from storage', () => {
+      mockStorage.getItem.mockReturnValue(JSON.stringify([
+        { date: '2026-03-29', done: 2, cancelled: 1, active: 3, total: 6 }
+      ]));
+
+      expect(loadBurndownData(mockStorage)).toEqual([
+        { date: '2026-03-29', done: 2, cancelled: 1, active: 3, total: 6 }
+      ]);
+      expect(mockStorage.getItem).toHaveBeenCalledWith('todos_burndown');
+    });
+
+    it('returns empty array for invalid burndown JSON', () => {
+      mockStorage.getItem.mockReturnValue('{not valid');
+      expect(loadBurndownData(mockStorage)).toEqual([]);
+    });
+
+    it('drops invalid samples and keeps valid stored totals', () => {
+      mockStorage.getItem.mockReturnValue(JSON.stringify([
+        { date: 'bad-date', done: 2, cancelled: 0, active: 1, total: 3 },
+        { date: '2026-03-29', done: 2, cancelled: 1, active: 3, total: 1 }
+      ]));
+
+      expect(loadBurndownData(mockStorage)).toEqual([
+        { date: '2026-03-29', done: 2, cancelled: 1, active: 3, total: 1 }
+      ]);
+    });
+  });
+
+  describe('saveBurndownData', () => {
+    it('saves pruned burndown samples', () => {
+      const samples = [
+        { date: '2026-02-26', done: 1, cancelled: 0, active: 1, total: 2 },
+        { date: '2026-03-01', done: 2, cancelled: 0, active: 1, total: 3 },
+        { date: '2026-03-29', done: 3, cancelled: 1, active: 1, total: 5 }
+      ];
+
+      const result = saveBurndownData(samples, mockStorage, 'todos_burndown', new Date(2026, 2, 29, 8, 0));
+
+      expect(result).toEqual([
+        { date: '2026-03-01', done: 2, cancelled: 0, active: 1, total: 3 },
+        { date: '2026-03-29', done: 3, cancelled: 1, active: 1, total: 5 }
+      ]);
+      expect(mockStorage.setItem).toHaveBeenCalledWith('todos_burndown', JSON.stringify(result));
+    });
+
+    it('keeps only the latest sample for a duplicate date', () => {
+      const result = saveBurndownData([
+        { date: '2026-03-29', done: 1, cancelled: 0, active: 2, total: 3 },
+        { date: '2026-03-29', done: 2, cancelled: 0, active: 2, total: 4 }
+      ], mockStorage, 'todos_burndown', new Date(2026, 2, 29, 8, 0));
+
+      expect(result).toEqual([
+        { date: '2026-03-29', done: 2, cancelled: 0, active: 2, total: 4 }
+      ]);
+    });
   });
 });
 
@@ -990,5 +1061,202 @@ describe('updateTodoText', () => {
     const todos = [{ id: '1', text: 'task', status: 'active' }];
     const result = updateTodoText(todos, '1', 'new text');
     expect(result[0].id).toBe('1');
+  });
+});
+
+function formatDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function createStableNow() {
+  const anchor = new Date(2026, 1, 15, 12, 0, 0, 0);
+  const offsetHours = anchor.getTimezoneOffset() / 60;
+  const minHour = Math.ceil(Math.max(0, -offsetHours));
+  const maxHour = Math.floor(Math.min(23, 23 - offsetHours));
+  const safeHour = Math.floor((minHour + maxHour) / 2);
+  return new Date(2026, 1, 15, safeHour, 0, 0, 0);
+}
+
+function shiftDays(date, deltaDays) {
+  const shifted = new Date(date);
+  shifted.setDate(shifted.getDate() + deltaDays);
+  return shifted;
+}
+
+describe('takeBurndownSample', () => {
+  const stableNow = createStableNow();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(stableNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns counts for mixed statuses with blocked included as active', () => {
+    const todos = [
+      { id: '1', text: 'done one', status: 'done' },
+      { id: '2', text: 'done two', status: 'done' },
+      { id: '3', text: 'cancelled task', status: 'cancelled' },
+      { id: '4', text: 'active one', status: 'active' },
+      { id: '5', text: 'active two', status: 'active' },
+      { id: '6', text: 'active three', status: 'active' },
+      { id: '7', text: 'blocked task', status: 'blocked', blockedBy: ['1'] }
+    ];
+
+    expect(model.takeBurndownSample(todos)).toEqual({
+      date: formatDate(stableNow),
+      done: 2,
+      cancelled: 1,
+      active: 4,
+      total: 7
+    });
+  });
+
+  it('returns zero done and cancelled when all todos are active', () => {
+    const todos = [
+      { id: '1', text: 'task one', status: 'active' },
+      { id: '2', text: 'task two', status: 'active' },
+      { id: '3', text: 'task three', status: 'active' }
+    ];
+
+    expect(model.takeBurndownSample(todos)).toEqual({
+      date: formatDate(stableNow),
+      done: 0,
+      cancelled: 0,
+      active: 3,
+      total: 3
+    });
+  });
+
+  it('returns zero active when all todos are done', () => {
+    const todos = [
+      { id: '1', text: 'task one', status: 'done' },
+      { id: '2', text: 'task two', status: 'done' },
+      { id: '3', text: 'task three', status: 'done' }
+    ];
+
+    expect(model.takeBurndownSample(todos)).toEqual({
+      date: formatDate(stableNow),
+      done: 3,
+      cancelled: 0,
+      active: 0,
+      total: 3
+    });
+  });
+
+  it('returns zero counts for an empty todo list', () => {
+    expect(model.takeBurndownSample([])).toEqual({
+      date: formatDate(stableNow),
+      done: 0,
+      cancelled: 0,
+      active: 0,
+      total: 0
+    });
+  });
+
+  it('returns today as a YYYY-MM-DD date string', () => {
+    const result = model.takeBurndownSample([]);
+    expect(result.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.date).toBe(formatDate(stableNow));
+  });
+});
+
+describe('shouldSampleToday', () => {
+  const stableNow = createStableNow();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(stableNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns true when no samples exist', () => {
+    expect(model.shouldSampleToday([])).toBe(true);
+  });
+
+  it('returns false when today already has a sample', () => {
+    const data = [
+      { date: formatDate(stableNow), done: 2, cancelled: 1, active: 3, total: 6 }
+    ];
+
+    expect(model.shouldSampleToday(data)).toBe(false);
+  });
+
+  it('returns true when only yesterday has a sample', () => {
+    const data = [
+      { date: formatDate(shiftDays(stableNow, -1)), done: 2, cancelled: 1, active: 3, total: 6 }
+    ];
+
+    expect(model.shouldSampleToday(data)).toBe(true);
+  });
+
+  it('returns true when multiple samples exist but none are from today', () => {
+    const data = [
+      { date: formatDate(shiftDays(stableNow, -2)), done: 1, cancelled: 0, active: 4, total: 5 },
+      { date: formatDate(shiftDays(stableNow, -7)), done: 3, cancelled: 1, active: 2, total: 6 },
+      { date: formatDate(shiftDays(stableNow, -30)), done: 4, cancelled: 1, active: 1, total: 6 }
+    ];
+
+    expect(model.shouldSampleToday(data)).toBe(true);
+  });
+});
+
+describe('pruneBurndownData', () => {
+  const stableNow = createStableNow();
+
+  const makeSample = (daysAgo, overrides = {}) => ({
+    date: formatDate(shiftDays(stableNow, -daysAgo)),
+    done: 1,
+    cancelled: 0,
+    active: 2,
+    total: 3,
+    ...overrides
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(stableNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps all entries that are within the last 30 days', () => {
+    const data = [makeSample(0), makeSample(5), makeSample(30)];
+    expect(model.pruneBurndownData(data)).toEqual(data);
+  });
+
+  it('removes only entries older than 30 days', () => {
+    const withinWindow = makeSample(0, { done: 3 });
+    const boundary = makeSample(30, { done: 4 });
+    const oldOne = makeSample(31, { done: 5 });
+    const oldTwo = makeSample(45, { done: 6 });
+    const data = [oldTwo, withinWindow, oldOne, boundary];
+
+    expect(model.pruneBurndownData(data)).toEqual([withinWindow, boundary]);
+  });
+
+  it('returns an empty array when all entries are older than 30 days', () => {
+    const data = [makeSample(31), makeSample(60)];
+    expect(model.pruneBurndownData(data)).toEqual([]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(model.pruneBurndownData([])).toEqual([]);
+  });
+
+  it('keeps an entry that is exactly 30 days old', () => {
+    const boundaryEntry = makeSample(30, { done: 9, total: 12 });
+    expect(model.pruneBurndownData([boundaryEntry])).toEqual([boundaryEntry]);
   });
 });


### PR DESCRIPTION
## What

Implements **PRD-burndown-view.md** — the final feature PRD. A lightweight progress chart showing cumulative work done vs scope growth.

### Features
- **Daily auto-sampling** of task counts to `localStorage` (`todos_burndown`)
- **Dual-line SVG chart**: Completed (done+cancelled) vs Total, over 30 days
- **Collapsible section**: "Progress" toggle, hidden by default
- **Prominent summary**: "N of M done (X%) · Y remaining"
- **Collapsed summary**: "N done · Y remaining · +Z done today"
- **Hover tooltips** with date, completed count, and total count
- **30-day rolling window** with auto-pruning
- **Responsive**: fewer x-axis labels on mobile (<480px)
- **Early state**: "Not enough data yet..." when <3 data points

### Testing
- 158 tests pass (135 model + 23 DAG)
- `npm run build` clean
- 14 new tests for `takeBurndownSample`, `shouldSampleToday`, `pruneBurndownData`

---
*Built by Rusty (implementation) and Linus (tests). Last of 4 feature PRDs.*