### PR TITLE
Fix blocker picker toggle and DAG status styling

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -10,6 +10,16 @@
 
 <!-- Append learnings below -->
 
+### 2026-03-29: Blocker Picker Label Activation + DAG Status Parity
+
+**What I changed:**
+- Fixed the blocked-task picker so clicking blocker text toggles the checkbox again by giving each checkbox a stable `id`, wiring the label with `htmlFor`, and stopping picker clicks from bubbling into the row selection handler.
+- Updated DAG node palettes so `done` tasks use the same green highlight language as the list, and `cancelled` tasks now get their own tinted red treatment instead of looking like faded default nodes.
+
+**Interaction rules to preserve:**
+- Nested interactive controls inside a clickable task row should stop event bubbling when the row click would otherwise steal or neutralize the control’s default behavior.
+- Status styling should stay consistent between the task list and the dependency graph so users can recognize done/cancelled states in either view without relearning the color system.
+
 ### 2026-03-29: Done State Highlight Refresh
 
 **What I changed:**

--- a/src/dag/view.js
+++ b/src/dag/view.js
@@ -87,22 +87,22 @@ function getStatusPalette(status) {
 
   if (status === 'done') {
     return {
-      fill: '#ffffff',
-      border: '#c8c8c8',
-      accent: null,
-      text: '#1a1a1a',
-      opacity: '0.6',
-      strike: '#999999'
+      fill: 'rgba(76, 175, 80, 0.08)',
+      border: '#4caf50',
+      accent: '#4caf50',
+      text: '#5f6f62',
+      opacity: '1',
+      strike: 'rgba(95, 111, 98, 0.7)'
     };
   }
 
   if (status === 'cancelled') {
     return {
-      fill: '#ffffff',
+      fill: 'rgba(192, 57, 43, 0.08)',
       border: '#d7a8a3',
-      accent: null,
+      accent: '#c0392b',
       text: '#c0392b',
-      opacity: '0.5',
+      opacity: '0.8',
       strike: '#c0392b'
     };
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1012,6 +1012,9 @@ if (typeof document !== 'undefined') {
 
           const picker = document.createElement('div');
           picker.className = 'blocker-picker';
+          picker.addEventListener('click', (event) => {
+            event.stopPropagation();
+          });
 
           const pickerTitle = document.createElement('div');
           pickerTitle.className = 'blocker-picker-title';
@@ -1028,7 +1031,10 @@ if (typeof document !== 'undefined') {
           } else {
             eligible.forEach(t => {
               const label = document.createElement('label');
+              const checkboxId = `blocker-${todo.id}-${t.id}`;
+              label.htmlFor = checkboxId;
               const cb = document.createElement('input');
+              cb.id = checkboxId;
               cb.type = 'checkbox';
               cb.checked = Array.isArray(todo.blockedBy) && todo.blockedBy.includes(t.id);
               cb.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- restore blocker picker label toggling by explicitly associating labels and checkboxes
- keep blocker picker clicks from bubbling into the task row handler
- match done/cancelled DAG node styling to the list state colors

Fixes #18, fixes #23

## Verification
- npm test
- npm run build