### PR TITLE
Fix #31 — README license does not match actual

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Works in all modern browsers (Chrome, Firefox, Safari). Keyboard navigation, ARI
 
 ## 📝 License
 
-ISC
+MIT
 
 ---
 


### PR DESCRIPTION
The LICENSE file uses MIT, and package.json specifies MIT, but README.md incorrectly stated ISC. This PR updates README.md to reflect the actual MIT license for consistency.

Fixes #31