### PR TITLE
Fix active label and add inline progress

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -10,6 +10,17 @@
 
 <!-- Append learnings below -->
 
+### 2026-03-30: Active Label Copy + Inline Progress Summary
+
+**What I changed:**
+- Renamed the status dropdown’s active option from “— None —” to “Active” and removed the muted placeholder-style text color so the control reads like a real state selector.
+- Added a persistent lightweight progress summary directly under the actionable filter, using the existing burndown sample counts to show completed-or-cancelled work as “X of Y done (Z%)” plus a thin inline bar.
+
+**UI rules to preserve:**
+- If a status value is a real selectable state, style it with the same readable text color as the other options instead of placeholder grey.
+- Keep the inline progress summary always visible near the list controls so users can glance at current completion without opening the sidebar burndown view.
+
+
 ### 2026-03-30: Full-Viewport Confetti Tuning
 
 **What I changed:**

--- a/index.html
+++ b/index.html
@@ -170,6 +170,32 @@
       font-size: 0.875rem;
     }
 
+    #task-progress {
+      margin: 0 0 1rem;
+    }
+
+    #task-progress-summary {
+      margin: 0 0 0.35rem;
+      color: #667085;
+      font-size: 0.875rem;
+    }
+
+    .task-progress-bar {
+      width: 100%;
+      height: 4px;
+      border-radius: 999px;
+      background: #e6ebf1;
+      overflow: hidden;
+    }
+
+    #task-progress-fill {
+      width: 0%;
+      height: 100%;
+      border-radius: inherit;
+      background: #73b88f;
+      transition: width 0.2s ease;
+    }
+
     .input-row label {
       position: absolute;
       width: 1px;
@@ -1354,6 +1380,13 @@
           <button type="button" id="actionable-filter-toggle" aria-pressed="false">Actionable</button>
           <div class="list-toolbar-copy">
             <p id="actionable-summary" role="status">0 of 0 tasks are actionable</p>
+          </div>
+        </div>
+
+        <div id="task-progress" aria-label="Task progress">
+          <p id="task-progress-summary">0 of 0 done (0%)</p>
+          <div class="task-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-labelledby="task-progress-summary">
+            <div id="task-progress-fill"></div>
           </div>
         </div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -195,6 +195,9 @@ if (typeof document !== 'undefined') {
     const unblockedNotificationDismiss = document.getElementById('unblocked-notification-dismiss');
     const actionableFilterToggle = document.getElementById('actionable-filter-toggle');
     const actionableSummary = document.getElementById('actionable-summary');
+    const taskProgressSummary = document.getElementById('task-progress-summary');
+    const taskProgressBar = document.querySelector('.task-progress-bar');
+    const taskProgressFill = document.getElementById('task-progress-fill');
     const emptyState = document.getElementById('empty-state');
     const burndownToggle = document.getElementById('burndown-toggle');
     const burndownCollapsedSummary = document.getElementById('burndown-collapsed-summary');
@@ -1025,8 +1028,13 @@ if (typeof document !== 'undefined') {
       }
 
       const { actionable, total } = getActionableCount(todos);
+      const { done, cancelled, total: progressTotal } = takeBurndownSample(todos);
       const visibleTodos = getVisibleTodos();
       const showActionableEmptyState = filterActive && total > 0 && actionable === 0;
+      const completedCount = done + cancelled;
+      const completionPercent = progressTotal > 0
+        ? Math.round((completedCount / progressTotal) * 100)
+        : 0;
 
       if (!visibleTodos.some(todo => todo.id === selectedTaskId)) {
         selectedTaskId = null;
@@ -1039,6 +1047,9 @@ if (typeof document !== 'undefined') {
       actionableFilterToggle.classList.toggle('is-active', filterActive);
       actionableFilterToggle.setAttribute('aria-pressed', String(filterActive));
       actionableSummary.textContent = `${actionable} of ${total} tasks are actionable`;
+      taskProgressSummary.textContent = `${completedCount} of ${progressTotal} done (${completionPercent}%)`;
+      taskProgressBar.setAttribute('aria-valuenow', String(completionPercent));
+      taskProgressFill.style.width = `${completionPercent}%`;
       emptyState.hidden = total > 0 ? !showActionableEmptyState : false;
       emptyState.textContent = total === 0
         ? 'No todos yet. Add one above!'
@@ -1068,7 +1079,7 @@ if (typeof document !== 'undefined') {
         select.className = 'todo-status';
         select.setAttribute('aria-label', `Status for "${todo.text}"`);
         const statusOptions = [
-          { value: 'active', label: '— None —' },
+          { value: 'active', label: 'Active' },
           { value: 'done', label: 'Done' },
           { value: 'cancelled', label: 'Cancelled' },
           { value: 'blocked', label: 'Blocked' }
@@ -1080,7 +1091,7 @@ if (typeof document !== 'undefined') {
           if (s.value === todo.status) opt.selected = true;
           select.appendChild(opt);
         });
-        select.style.color = todo.status === 'active' ? '#999' : '#1a1a1a';
+        select.style.color = '#1a1a1a';
         select.addEventListener('change', () => {
           const nextStatus = select.value;
           const currentTodo = todos.find(item => item.id === todo.id);


### PR DESCRIPTION
## Summary
- rename the active status option from placeholder copy to Active and keep its text color readable
- add an always-visible inline progress summary and mini progress bar above the todo list
- record the UI learnings in Rusty's history

## Testing
- npm test
- npm run build

Fixes #36, fixes #37