### PR TITLE
Allow in-progress tasks as blockers

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -310,4 +310,14 @@
 
 **UI rules to preserve:**
 - Control chrome should stay on the 6px / 8px / pill radius system: interactive controls use the control radius, elevated surfaces use the surface radius, and passive badges stay fully rounded.
+
+### 2026-03-30: In-Progress Tasks as Valid Blockers
+
+**What I changed:**
+- Expanded `BLOCKER_SOURCE_TODO_STATUSES` so the blocked-task picker now lists `todo`, `inprogress`, and `blocked` tasks as valid blockers while still excluding finished work.
+- Verified the model/store flow already treats in-progress blockers as active dependencies, then added regression coverage to lock in unblock notifications when an in-progress blocker moves to `done`.
+- Added a DAG regression test to confirm dependency edges and node statuses render normally when the upstream blocker is already in progress.
+
+**Interaction rule to preserve:**
+- Blocker eligibility should be driven from the shared status constant, not reimplemented in the picker, so list UI, unblock logic, and DAG rendering stay aligned when dependency rules change.
 - If a status color changes, update it in `src/app/constants.js` and let the runtime CSS-variable sync fan it out across CSS and SVG renderers instead of hand-tuning individual surfaces.

--- a/.squad/decisions/inbox/rusty-inprogress-blockers.md
+++ b/.squad/decisions/inbox/rusty-inprogress-blockers.md
@@ -1,0 +1,5 @@
+# Rusty Inbox: In-Progress Blockers
+
+- Decision: blocked-task picker should allow blocker candidates with status `todo`, `inprogress`, or `blocked`.
+- Rationale: users can legitimately wait on work that is already underway, so dependency selection should include active in-flight tasks, not just untouched todos.
+- Guardrails: keep `done` and `cancelled` tasks out of blocker selection, and preserve existing unblock cleanup when a blocker transitions into a terminal state.

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -37,6 +37,7 @@ export const TOGGLEABLE_TODO_STATUSES = Object.freeze([
 
 export const BLOCKER_SOURCE_TODO_STATUSES = Object.freeze([
   TODO_STATUS.TODO,
+  TODO_STATUS.IN_PROGRESS,
   TODO_STATUS.BLOCKED,
 ]);
 

--- a/src/app/constants.test.js
+++ b/src/app/constants.test.js
@@ -18,6 +18,8 @@ const EXPECTED_STATUS_LABELS = {
   blocked: 'Blocked',
 };
 
+const EXPECTED_BLOCKER_SOURCE_STATUSES = ['todo', 'inprogress', 'blocked'];
+
 const EXPECTED_STATUS_PALETTE = {
   todo: {
     fill: '#ffffff',
@@ -146,6 +148,13 @@ function getStorageKeys() {
   return resolveExport(
     ['APP_STORAGE_KEYS', 'STORAGE_KEYS', 'LOCAL_STORAGE_KEYS'],
     'a storage key map',
+  );
+}
+
+function getBlockerSourceStatuses() {
+  return resolveExport(
+    ['BLOCKER_SOURCE_TODO_STATUSES', 'BLOCKER_SOURCE_STATUSES'],
+    'a blocker source status list',
   );
 }
 
@@ -288,6 +297,12 @@ describe('app constants contract', () => {
         storageKeys.TODOS,
         JSON.stringify([{ id: 'task-1', text: 'Persist me', status: 'todo' }]),
       );
+    });
+  });
+
+  describe('blocker source statuses', () => {
+    it('allows todo, in-progress, and blocked tasks as blocker candidates', () => {
+      expect(getBlockerSourceStatuses()).toEqual(EXPECTED_BLOCKER_SOURCE_STATUSES);
     });
   });
 

--- a/src/app/store.test.js
+++ b/src/app/store.test.js
@@ -106,6 +106,38 @@ describe('createAppStore', () => {
     expect(storage.data.get(APP_STORAGE_KEYS.READY_FILTER)).toBe('true');
   });
 
+  it('unblocks dependent tasks when an in-progress blocker is completed', () => {
+    const store = createAppStore({
+      storage: createStorage(),
+      initialState: createState({
+        todos: [
+          { id: 'a', text: 'Working blocker', status: TODO_STATUS.IN_PROGRESS },
+          {
+            id: 'b',
+            text: 'Blocked task',
+            status: TODO_STATUS.BLOCKED,
+            blockedBy: ['a'],
+          },
+        ],
+      }),
+    });
+
+    const event = store.setTaskStatus({
+      id: 'a',
+      nextStatus: TODO_STATUS.DONE,
+    });
+
+    expect(event.changed).toBe(true);
+    expect(event.meta).toMatchObject({
+      completedTaskId: 'a',
+      unblockedIds: ['b'],
+    });
+    expect(store.getState().todos).toEqual([
+      { id: 'a', text: 'Working blocker', status: TODO_STATUS.DONE },
+      { id: 'b', text: 'Blocked task', status: TODO_STATUS.TODO },
+    ]);
+  });
+
   it('loads tip dismissal preferences into store state', () => {
     const store = createAppStore({
       storage: createStorage({

--- a/src/dag/graph.test.js
+++ b/src/dag/graph.test.js
@@ -153,6 +153,38 @@ describe('buildDependencyGraph — Edge mapping', () => {
     );
   });
 
+  it('creates edges from in-progress blockers the same as todo blockers', () => {
+    const todos = [
+      { id: 'task-a', text: 'Task A', status: 'inprogress' },
+      {
+        id: 'task-b',
+        text: 'Task B',
+        status: 'blocked',
+        blockedBy: ['task-a'],
+      },
+    ];
+
+    const result = buildDependencyGraph(todos);
+
+    expect(result.edges).toEqual([
+      expect.objectContaining({ from: 'task-a', to: 'task-b' }),
+    ]);
+    expect(result.nodes).toEqual([
+      {
+        id: 'task-a',
+        label: 'Task A',
+        status: 'inprogress',
+        orderIndex: 0,
+      },
+      {
+        id: 'task-b',
+        label: 'Task B',
+        status: 'blocked',
+        orderIndex: 1,
+      },
+    ]);
+  });
+
   it('handles non-existent blocker ids without crashing', () => {
     const todos = [
       {


### PR DESCRIPTION
## Summary
- allow blocker picker candidates with todo, inprogress, and blocked statuses
- keep unblock cleanup working when an in-progress blocker moves to done
- add regression coverage for blocker-source status rules and DAG/store behavior

## Testing
- npm run lint
- npm test
- npm run build