### PR TITLE
Add privacy footer and first-run welcome hint

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -10,6 +10,17 @@
 
 <!-- Append learnings below -->
 
+### 2026-03-30: Privacy Messaging + First-Run Ownership Hint
+
+**What I changed:**
+- Added a warm inline welcome hint near the empty state, using the existing discoverability-tip pattern and a one-shot `localStorage` key so it only appears for true first-run/zero-task users.
+- Made the welcome hint dismissible and also auto-retired it once a user already has tasks, so returning users do not see onboarding copy after they have established local data.
+- Added a subtle footer privacy note at the bottom of the app using muted typography to reinforce the product promise without turning it into a legal disclaimer.
+
+**UI rules to preserve:**
+- Privacy/ownership messaging should feel calm and confidence-building: inline, brief, token-driven, and visually quieter than task controls.
+- First-run guidance belongs in the existing discoverability-tip system with centralized storage keys and persistent dismissal, not in a modal or ad-hoc banner.
+
 ### 2026-03-30: Burndown Removal + Header Metrics
 
 **What I changed:**

--- a/index.html
+++ b/index.html
@@ -115,6 +115,28 @@
             ></div>
           </div>
 
+          <div
+            id="welcome-tip"
+            class="discovery-tip discovery-tip-welcome"
+            role="status"
+            aria-live="polite"
+            hidden
+          >
+            <span class="discovery-tip-copy"
+              >👋 Welcome to Bumbledo! Your tasks live right here in your
+              browser — no accounts, no cloud, nothing leaves this device. Add
+              your first task to get started.</span
+            >
+            <button
+              type="button"
+              id="welcome-tip-dismiss"
+              class="discovery-tip-dismiss control-button control-button-icon control-button-quiet"
+              aria-label="Dismiss welcome tip"
+            >
+              ×
+            </button>
+          </div>
+
           <p id="empty-state" role="status">
             Your hive is empty — add a task to get buzzing 🐝
           </p>
@@ -187,6 +209,11 @@
           them.
         </p>
       </section>
+
+      <p class="privacy-note">
+        Everything stays in your browser. No accounts. No servers. Just your
+        tasks.
+      </p>
     </div>
 
     <div class="shortcut-help-modal" id="shortcuts-help-modal" hidden>

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -194,6 +194,7 @@ export const APP_STORAGE_KEYS = Object.freeze({
   TODOS: 'todos',
   READY_FILTER: 'bumbledo_filter_ready',
   LEGACY_ACTIONABLE_FILTER: 'bumbledo_filter_actionable',
+  WELCOME_TIP_DISMISSED: 'bumbledo_tip_welcome_dismissed',
   SHORTCUTS_TIP_DISMISSED: 'bumbledo_tip_shortcuts_dismissed',
   REORDER_TIP_DISMISSED: 'bumbledo_tip_reorder_dismissed',
 });

--- a/src/app/constants.test.js
+++ b/src/app/constants.test.js
@@ -67,6 +67,7 @@ const EXPECTED_STORAGE_KEYS = {
   TODOS: 'todos',
   READY_FILTER: 'bumbledo_filter_ready',
   LEGACY_ACTIONABLE_FILTER: 'bumbledo_filter_actionable',
+  WELCOME_TIP_DISMISSED: 'bumbledo_tip_welcome_dismissed',
   SHORTCUTS_TIP_DISMISSED: 'bumbledo_tip_shortcuts_dismissed',
   REORDER_TIP_DISMISSED: 'bumbledo_tip_reorder_dismissed',
 };

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -42,6 +42,28 @@ function loadBooleanPreference(storageKey, storage = defaultStorage) {
   }
 }
 
+function loadWelcomeTipPreference(
+  todos,
+  storageKey = APP_STORAGE_KEYS.WELCOME_TIP_DISMISSED,
+  storage = defaultStorage,
+) {
+  try {
+    const stored = storage.getItem(storageKey);
+    if (stored !== null) {
+      return stored === 'true';
+    }
+
+    if (todos.length > 0) {
+      saveBooleanPreference(storageKey, true, storage);
+      return true;
+    }
+
+    return false;
+  } catch {
+    return todos.length > 0;
+  }
+}
+
 function loadReadyFilterPreference(storage = defaultStorage) {
   try {
     const storedPreference = storage.getItem(APP_STORAGE_KEYS.READY_FILTER);
@@ -102,15 +124,18 @@ function reconcileSelection(state) {
 function buildInitialState({
   storage = defaultStorage,
   isMobileViewport = false,
-  } = {}) {
+} = {}) {
+  const todos = loadTodos(storage);
+
   return {
-    todos: loadTodos(storage),
+    todos,
     selectedTaskId: null,
     filterActive: loadReadyFilterPreference(storage),
     dagExpanded: !isMobileViewport,
     dagToggleTouched: false,
     editingId: null,
     isMobileViewport,
+    welcomeTipDismissed: loadWelcomeTipPreference(todos, undefined, storage),
     shortcutsTipDismissed: loadBooleanPreference(
       APP_STORAGE_KEYS.SHORTCUTS_TIP_DISMISSED,
       storage,
@@ -146,6 +171,16 @@ export function createAppStore(options = {}) {
         saveBooleanPreference(
           APP_STORAGE_KEYS.READY_FILTER,
           nextState.filterActive,
+          storage,
+        ),
+    },
+    {
+      shouldRun: (previousState, nextState) =>
+        previousState.welcomeTipDismissed !== nextState.welcomeTipDismissed,
+      run: (_previousState, nextState) =>
+        saveBooleanPreference(
+          APP_STORAGE_KEYS.WELCOME_TIP_DISMISSED,
+          nextState.welcomeTipDismissed,
           storage,
         ),
     },
@@ -190,6 +225,7 @@ export function createAppStore(options = {}) {
         ...currentState,
         todos: nextTodos,
         editingId: null,
+        welcomeTipDismissed: true,
       });
     },
     clearFinished(currentState) {
@@ -259,6 +295,13 @@ export function createAppStore(options = {}) {
       }
 
       return { ...currentState, shortcutsTipDismissed: true };
+    },
+    dismissWelcomeTip(currentState) {
+      if (currentState.welcomeTipDismissed) {
+        return currentState;
+      }
+
+      return { ...currentState, welcomeTipDismissed: true };
     },
     enterEditMode(currentState, payload = {}) {
       const todo = currentState.todos.find((item) => item.id === payload.id);

--- a/src/app/store.test.js
+++ b/src/app/store.test.js
@@ -27,6 +27,7 @@ function createState(overrides = {}) {
     dagToggleTouched: false,
     editingId: null,
     isMobileViewport: false,
+    welcomeTipDismissed: false,
     shortcutsTipDismissed: false,
     reorderTipDismissed: false,
     ...overrides,
@@ -141,12 +142,14 @@ describe('createAppStore', () => {
   it('loads tip dismissal preferences into store state', () => {
     const store = createAppStore({
       storage: createStorage({
+        [APP_STORAGE_KEYS.WELCOME_TIP_DISMISSED]: 'true',
         [APP_STORAGE_KEYS.SHORTCUTS_TIP_DISMISSED]: 'true',
         [APP_STORAGE_KEYS.REORDER_TIP_DISMISSED]: 'true',
       }),
     });
 
     expect(store.getState()).toMatchObject({
+      welcomeTipDismissed: true,
       shortcutsTipDismissed: true,
       reorderTipDismissed: true,
     });
@@ -156,15 +159,30 @@ describe('createAppStore', () => {
     const storage = createStorage();
     const store = createAppStore({ storage, initialState: createState() });
 
+    store.dismissWelcomeTip();
     store.dismissShortcutsTip();
     store.dismissReorderTip();
 
+    expect(storage.data.get(APP_STORAGE_KEYS.WELCOME_TIP_DISMISSED)).toBe('true');
     expect(storage.data.get(APP_STORAGE_KEYS.SHORTCUTS_TIP_DISMISSED)).toBe(
       'true',
     );
     expect(storage.data.get(APP_STORAGE_KEYS.REORDER_TIP_DISMISSED)).toBe(
       'true',
     );
+  });
+
+  it('treats the welcome hint as one-shot once a task already exists', () => {
+    const storage = createStorage({
+      [APP_STORAGE_KEYS.TODOS]: JSON.stringify([
+        { id: 'task-1', text: 'Existing task', status: TODO_STATUS.TODO },
+      ]),
+    });
+
+    const store = createAppStore({ storage });
+
+    expect(store.getState().welcomeTipDismissed).toBe(true);
+    expect(storage.data.get(APP_STORAGE_KEYS.WELCOME_TIP_DISMISSED)).toBe('true');
   });
 
 });

--- a/src/main.js
+++ b/src/main.js
@@ -75,6 +75,8 @@ if (typeof document !== 'undefined') {
       'task-progress-summary',
     );
     const taskProgressBar = document.querySelector('.task-progress-bar');
+    const welcomeTip = document.getElementById('welcome-tip');
+    const welcomeTipDismiss = document.getElementById('welcome-tip-dismiss');
     const emptyState = document.getElementById('empty-state');
     const reorderTip = document.getElementById('reorder-tip');
     const reorderTipDismiss = document.getElementById('reorder-tip-dismiss');
@@ -104,6 +106,7 @@ if (typeof document !== 'undefined') {
     let filterActive = false;
     let dagExpanded = false;
     let editingId = null;
+    let welcomeTipDismissed = false;
     let shortcutsTipDismissed = false;
     let reorderTipDismissed = false;
 
@@ -116,6 +119,7 @@ if (typeof document !== 'undefined') {
         filterActive,
         dagExpanded,
         editingId,
+        welcomeTipDismissed,
         shortcutsTipDismissed,
         reorderTipDismissed,
       } = nextState);
@@ -277,11 +281,20 @@ if (typeof document !== 'undefined') {
       store.dismissShortcutsTip();
     }
 
+    function dismissWelcomeTip() {
+      store.dismissWelcomeTip();
+    }
+
     function dismissReorderTip() {
       store.dismissReorderTip();
     }
 
     function syncDiscoverabilityTips() {
+      if (welcomeTip) {
+        const shouldShowWelcomeTip = !welcomeTipDismissed && todos.length === 0;
+        welcomeTip.hidden = !shouldShowWelcomeTip;
+      }
+
       if (shortcutsTip) {
         const shouldShowShortcutsTip =
           !shortcutsTipDismissed && todos.length >= 3;
@@ -552,6 +565,10 @@ if (typeof document !== 'undefined') {
 
     shortcutsTipDismiss?.addEventListener('click', () => {
       dismissShortcutsTip();
+    });
+
+    welcomeTipDismiss?.addEventListener('click', () => {
+      dismissWelcomeTip();
     });
 
     reorderTipDismiss?.addEventListener('click', () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -565,6 +565,19 @@ header .brand-tagline {
   display: none;
 }
 
+.discovery-tip-welcome {
+  background: color-mix(
+    in srgb,
+    var(--color-accent-surface) 58%,
+    var(--color-surface-muted)
+  );
+  border-color: color-mix(
+    in srgb,
+    var(--color-accent-border) 70%,
+    var(--color-border-subtle)
+  );
+}
+
 .discovery-tip-copy {
   flex: 1;
 }
@@ -867,6 +880,15 @@ footer {
   justify-content: center;
   gap: var(--space-md);
   flex-wrap: wrap;
+}
+
+.privacy-note {
+  margin-top: var(--space-xl);
+  padding-bottom: var(--space-sm);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  line-height: 1.4;
 }
 
 #clear-finished-btn {


### PR DESCRIPTION
## Summary\n- add a subtle privacy/ownership footer note at the bottom of the app\n- add a first-run dismissible welcome hint for empty local task lists\n- persist the welcome hint as a one-shot discoverability tip using localStorage\n\n## Testing\n- npm test\n- npm run build\n- npm run lint