### PR TITLE
Add blocker-impact warning for destructive actions

### DIFF
--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -116,6 +116,16 @@ export function selectBlockedStatusChange(state, todoId, nextStatus) {
   };
 }
 
+export function selectDependentCount(state, taskId) {
+  return state.todos.reduce((count, todo) => {
+    if (!Array.isArray(todo.blockedBy) || !todo.blockedBy.includes(taskId)) {
+      return count;
+    }
+
+    return count + 1;
+  }, 0);
+}
+
 export function selectToggleStatusTarget(state) {
   const todo = selectSelectedTodo(state);
   if (!todo || !TOGGLEABLE_STATUS_SET.has(todo.status)) {

--- a/src/app/selectors.test.js
+++ b/src/app/selectors.test.js
@@ -3,6 +3,7 @@ import { TODO_STATUS } from './constants.js';
 import {
   selectBlockedStatusChange,
   selectDagViewModel,
+  selectDependentCount,
   selectProgress,
   selectShowReadyEmptyState,
   selectToggleStatusTarget,
@@ -177,6 +178,30 @@ describe('selectors', () => {
       blockedCompletionAttempt: false,
       activeBlockerCount: 0,
     });
+  });
+
+  it('counts downstream dependents for blocker warnings', () => {
+    const state = createState({
+      todos: [
+        { id: 'a', text: 'Blocker', status: TODO_STATUS.IN_PROGRESS },
+        {
+          id: 'b',
+          text: 'Blocked task',
+          status: TODO_STATUS.BLOCKED,
+          blockedBy: ['a'],
+        },
+        {
+          id: 'c',
+          text: 'Another blocked task',
+          status: TODO_STATUS.BLOCKED,
+          blockedBy: ['z', 'a'],
+        },
+        { id: 'd', text: 'Done task', status: TODO_STATUS.DONE },
+      ],
+    });
+
+    expect(selectDependentCount(state, 'a')).toBe(2);
+    expect(selectDependentCount(state, 'd')).toBe(0);
   });
 
   it('returns selected toggle target details when selection is actionable', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { createAppStore } from './app/store.js';
 import {
   selectBlockedStatusChange,
   selectDagViewModel,
+  selectDependentCount,
   selectHasFinishedTodos,
   selectProgress,
   selectShowReadyEmptyState,
@@ -25,6 +26,7 @@ import {
   renderStatusMetricLine,
 } from './ui/status-metrics.js';
 import { createTodoListView } from './todo/list-view.js';
+import { confirmBlockerImpact } from './todo/blocker-warning.js';
 import { createNotificationController } from './todo/notification.js';
 import { createTodoReorderController } from './todo/reorder.js';
 import { reorderTodos, wouldCreateCycle } from './todo/model.js';
@@ -137,6 +139,36 @@ if (typeof document !== 'undefined') {
     });
 
     let notificationController;
+
+    function confirmDeleteTask(id) {
+      const dependentCount = selectDependentCount(store.getState(), id);
+      return confirmBlockerImpact({ action: 'delete', dependentCount });
+    }
+
+    function revertStatusControl(id, returnFocusEl) {
+      const todo = store.getState().todos.find((item) => item.id === id);
+      if (!(returnFocusEl instanceof HTMLSelectElement) || !todo) {
+        return;
+      }
+
+      returnFocusEl.value = todo.status;
+      returnFocusEl.focus();
+    }
+
+    function confirmCancelledStatusChange(id, returnFocusEl = null) {
+      const dependentCount = selectDependentCount(store.getState(), id);
+      const confirmed = confirmBlockerImpact({
+        action: 'cancel',
+        dependentCount,
+      });
+
+      if (!confirmed) {
+        revertStatusControl(id, returnFocusEl);
+      }
+
+      return confirmed;
+    }
+
     const listView = createTodoListView({
       container: todoList,
       getHighlightRemainingMs: (id) =>
@@ -160,9 +192,18 @@ if (typeof document !== 'undefined') {
         store.cancelEdit();
       },
       onDeleteTask: (id) => {
+        if (!confirmDeleteTask(id)) {
+          return;
+        }
         store.deleteTask({ id });
       },
       onStatusChange: (id, nextStatus, { returnFocusEl = null } = {}) => {
+        if (
+          nextStatus === TODO_STATUS.CANCELLED &&
+          !confirmCancelledStatusChange(id, returnFocusEl)
+        ) {
+          return;
+        }
         store.setTaskStatus({ id, nextStatus, returnFocusEl });
       },
       onToggleBlocker: (todoId, blockerId) => {
@@ -222,7 +263,7 @@ if (typeof document !== 'undefined') {
           modals.closeHelp();
         },
         deleteSelectedTodo: () => {
-          if (selectedTaskId) {
+          if (selectedTaskId && confirmDeleteTask(selectedTaskId)) {
             store.deleteTask({ id: selectedTaskId });
           }
         },

--- a/src/todo/blocker-warning.js
+++ b/src/todo/blocker-warning.js
@@ -1,0 +1,21 @@
+const ACTION_LABELS = {
+  cancel: 'Cancelling',
+  delete: 'Deleting',
+};
+
+export function getBlockerImpactMessage(action, dependentCount) {
+  const actionLabel = ACTION_LABELS[action] ?? 'Changing';
+  return `This task blocks ${dependentCount} other task(s). ${actionLabel} it will unblock them. Continue?`;
+}
+
+export function confirmBlockerImpact({
+  action,
+  dependentCount,
+  confirm = (message) => window.confirm(message),
+}) {
+  if (dependentCount === 0) {
+    return true;
+  }
+
+  return confirm(getBlockerImpactMessage(action, dependentCount));
+}

--- a/src/todo/blocker-warning.test.js
+++ b/src/todo/blocker-warning.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  confirmBlockerImpact,
+  getBlockerImpactMessage,
+} from './blocker-warning.js';
+
+describe('blocker warning helpers', () => {
+  it('builds the delete warning copy with the dependent count', () => {
+    expect(getBlockerImpactMessage('delete', 2)).toBe(
+      'This task blocks 2 other task(s). Deleting it will unblock them. Continue?',
+    );
+  });
+
+  it('builds the cancel warning copy with the dependent count', () => {
+    expect(getBlockerImpactMessage('cancel', 1)).toBe(
+      'This task blocks 1 other task(s). Cancelling it will unblock them. Continue?',
+    );
+  });
+
+  it('skips confirmation for non-blockers', () => {
+    const confirm = vi.fn();
+
+    expect(
+      confirmBlockerImpact({ action: 'delete', dependentCount: 0, confirm }),
+    ).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it('delegates blocker confirmation to the provided confirm function', () => {
+    const confirm = vi.fn(() => false);
+
+    expect(
+      confirmBlockerImpact({ action: 'cancel', dependentCount: 3, confirm }),
+    ).toBe(false);
+    expect(confirm).toHaveBeenCalledWith(
+      'This task blocks 3 other task(s). Cancelling it will unblock them. Continue?',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- warn before deleting a task that other tasks depend on
- warn before cancelling a task that other tasks depend on and restore the status select if the user aborts
- add selector/helper coverage for dependent counts and blocker warning copy

Closes #86